### PR TITLE
Update HeWeather.py

### DIFF
--- a/HeWeather.py
+++ b/HeWeather.py
@@ -255,7 +255,7 @@ class HeWeatherSensor(Entity):
         self._updatetime = None
 
     @property
-    def name(self):
+    def unique_id(self):
         return self._object_id
 
     @property


### PR DESCRIPTION
将name函数改成unique_id，这样friendly_name属性能正常设置，否则friendly_name会被设置成name。